### PR TITLE
Add email login, personal recipe book, and social share

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,10 @@ By addressing the critical issue of food waste and promoting efficient food mana
 ### 1. What is in the stack?
 
 - **Frontend**: [React](https://react.dev/) + [Vite](https://vitejs.dev/), styled with Bootstrap 5 (same UI as the original build).
-- **Backend**: two [Vercel serverless functions](https://vercel.com/docs/functions) (`/api/ingredients`, `/api/recipes`) that proxy the OpenAI API — this keeps the API key server-side and is where the daily rate limit is enforced.
+- **Backend**: [Vercel serverless functions](https://vercel.com/docs/functions) under `/api` — `/api/ingredients` and `/api/recipes` proxy the OpenAI API (keeps the key server-side, enforces the daily rate limit); `/api/auth/*` and `/api/recipe-book` handle login and each visitor's saved recipes.
 - **Rate limiting**: [Upstash Redis](https://vercel.com/marketplace/upstash) (via Vercel Marketplace), 5 calls per IP per day per endpoint.
+- **Database**: [Neon](https://neon.tech) (serverless Postgres) via `@neondatabase/serverless`, storing user accounts and saved recipes. Falls back to an in-process store when `DATABASE_URL` isn't set — fine for a quick UI check, but not reliable across requests (each serverless invocation gets a fresh process), so login/save only actually persists once a real Neon database is connected.
+- **Auth**: a minimal email-only login (no password, no verification email) — a signed, `httpOnly` cookie identifies the visitor. Good enough for gating a personal recipe book; not a substitute for real auth if the app ever handles sensitive data.
 - **Hosting**: [Vercel](https://vercel.com/).
 
 > The app previously ran on Symfony (PHP) — see git history before this rewrite if you need to reference that version.
@@ -129,10 +131,15 @@ npm install          # installs the /api function dependencies (@vercel/kv)
 cd web && npm install # installs the React app dependencies
 cd ..
 ```
-- Step 3: Set your OpenAI key locally (**⚠️ never commit this — `.env`/`.env.local` are already gitignored**). Use plain `.env` — for this no-framework project, `vercel dev` only auto-loads that one, not `.env.local`.
+- Step 3: Set your env vars locally (**⚠️ never commit these — `.env`/`.env.local` are already gitignored**). Use plain `.env` — for this no-framework project, `vercel dev` only auto-loads that one, not `.env.local`.
 ```bash
-echo "OPENAI_API_KEY=sk-..." > .env
+cat >> .env <<'EOF'
+OPENAI_API_KEY=sk-...
+SESSION_SECRET=some-long-random-string
+DATABASE_URL=postgresql://...   # from Neon console -> Connection Details -> Pooled connection
+EOF
 ```
+  `DATABASE_URL` is optional locally (login/save fall back to an in-memory store without it — see the Database note above), but `SESSION_SECRET` should still be set, and both are **required** in production. Optionally add `VITE_PLAY_STORE_URL` (the Play Store listing, once it exists) and `VITE_SITE_URL` (the deployed site URL, used in share captions) to `web/.env` — these are Vite-side, so they live under `web/`, not the repo root.
 - Step 4: Run the app with `vercel dev`, which serves the React app *and* the `/api` functions together on one port (rate-limiting falls back to an in-memory counter locally when no Redis store is linked, which is fine for local testing)
 ```bash
 vercel dev
@@ -146,7 +153,8 @@ vercel dev
 
 1. Import this repo into a new [Vercel](https://vercel.com/new) project (it auto-detects `vercel.json`).
 2. Project → **Storage** (or **Integrations → Marketplace**) → add an **Upstash Redis** database → connect it to the project (this injects the `KV_REST_API_URL`/`KV_REST_API_TOKEN` or `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` env vars the rate limiter needs).
-3. Project → **Settings → Environment Variables** → add `OPENAI_API_KEY`.
-4. Deploy — Vercel gives you a live `*.vercel.app` URL.
+3. Project → **Storage** → add a **Neon** database (or connect an existing Neon project) → this injects `DATABASE_URL`.
+4. Project → **Settings → Environment Variables** → add `OPENAI_API_KEY` and `SESSION_SECRET` (a long random string — e.g. `openssl rand -hex 32`). Optionally add `VITE_PLAY_STORE_URL` / `VITE_SITE_URL`.
+5. Deploy — Vercel gives you a live `*.vercel.app` URL.
 
 

--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -1,0 +1,130 @@
+// Neon Postgres access for user accounts + saved recipe books.
+//
+// Uses @neondatabase/serverless (HTTP driver, works great from Vercel
+// functions) when DATABASE_URL is set - grab that connection string from
+// the Neon console (Project -> Connection Details -> "Pooled connection").
+//
+// Falls back to an in-process in-memory store (same pattern as
+// _lib/rateLimit.js) when DATABASE_URL isn't set, so local dev works
+// without a Neon project linked. NOT persistent across restarts/instances
+// - local preview only. Production must have DATABASE_URL configured.
+
+const databaseUrl = process.env.DATABASE_URL;
+const hasDb = Boolean(databaseUrl);
+
+let sqlPromise;
+async function getSql() {
+  if (!sqlPromise) {
+    sqlPromise = (async () => {
+      const { neon } = await import('@neondatabase/serverless');
+      const sql = neon(databaseUrl);
+      await sql`
+        CREATE TABLE IF NOT EXISTS users (
+          id SERIAL PRIMARY KEY,
+          email TEXT UNIQUE NOT NULL,
+          created_at TIMESTAMPTZ DEFAULT now()
+        )
+      `;
+      await sql`
+        CREATE TABLE IF NOT EXISTS saved_recipes (
+          id SERIAL PRIMARY KEY,
+          user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          title TEXT NOT NULL,
+          is_healthy BOOLEAN NOT NULL DEFAULT false,
+          ingredients JSONB NOT NULL,
+          instructions JSONB NOT NULL,
+          created_at TIMESTAMPTZ DEFAULT now()
+        )
+      `;
+      return sql;
+    })();
+  }
+  return sqlPromise;
+}
+
+// ---------------- in-memory fallback (local dev only) ----------------
+
+const memUsers = new Map(); // email -> user
+const memRecipes = new Map(); // userId -> recipe[]
+let memNextUserId = 1;
+let memNextRecipeId = 1;
+
+// ---------------- public API ----------------
+
+export async function findOrCreateUser(email) {
+  if (hasDb) {
+    const sql = await getSql();
+    const rows = await sql`
+      INSERT INTO users (email) VALUES (${email})
+      ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email
+      RETURNING id, email, created_at AS "createdAt"
+    `;
+    return rows[0];
+  }
+  let user = memUsers.get(email);
+  if (!user) {
+    user = { id: memNextUserId++, email, createdAt: new Date().toISOString() };
+    memUsers.set(email, user);
+  }
+  return user;
+}
+
+export async function getUserByEmail(email) {
+  if (hasDb) {
+    const sql = await getSql();
+    const rows = await sql`SELECT id, email, created_at AS "createdAt" FROM users WHERE email = ${email}`;
+    return rows[0] || null;
+  }
+  return memUsers.get(email) || null;
+}
+
+export async function listSavedRecipes(userId) {
+  if (hasDb) {
+    const sql = await getSql();
+    return sql`
+      SELECT id, title, is_healthy AS "isHealthy", ingredients, instructions, created_at AS "createdAt"
+      FROM saved_recipes WHERE user_id = ${userId} ORDER BY created_at DESC
+    `;
+  }
+  return (memRecipes.get(userId) || []).slice().reverse();
+}
+
+export async function saveRecipe(userId, recipe) {
+  const { title, isHealthy, ingredients, instructions } = recipe;
+  if (hasDb) {
+    const sql = await getSql();
+    const rows = await sql`
+      INSERT INTO saved_recipes (user_id, title, is_healthy, ingredients, instructions)
+      VALUES (${userId}, ${title}, ${!!isHealthy}, ${JSON.stringify(ingredients)}::jsonb, ${JSON.stringify(instructions)}::jsonb)
+      RETURNING id, title, is_healthy AS "isHealthy", ingredients, instructions, created_at AS "createdAt"
+    `;
+    return rows[0];
+  }
+  const list = memRecipes.get(userId) || [];
+  const saved = {
+    id: memNextRecipeId++,
+    title,
+    isHealthy: !!isHealthy,
+    ingredients,
+    instructions,
+    createdAt: new Date().toISOString()
+  };
+  list.push(saved);
+  memRecipes.set(userId, list);
+  return saved;
+}
+
+export async function deleteRecipe(userId, recipeId) {
+  if (hasDb) {
+    const sql = await getSql();
+    await sql`DELETE FROM saved_recipes WHERE id = ${recipeId} AND user_id = ${userId}`;
+    return;
+  }
+  const list = memRecipes.get(userId) || [];
+  memRecipes.set(
+    userId,
+    list.filter((r) => r.id !== recipeId)
+  );
+}
+
+export const usingRealDatabase = hasDb;

--- a/api/_lib/session.js
+++ b/api/_lib/session.js
@@ -1,0 +1,59 @@
+// Minimal signed-cookie session used to gate "save my recipe book".
+//
+// This is intentionally lightweight: login is just an email address, no
+// password and no verification email. It's enough to let a returning
+// visitor keep a private recipe book without building a full auth stack,
+// but it means anyone who knows/guesses a visitor's email could sign in
+// as them. Fine for a low-stakes demo feature - swap in a real magic-link
+// or OTP email flow before this app holds anything sensitive.
+
+import crypto from 'crypto';
+
+const COOKIE_NAME = 'l2r_session';
+const MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
+const isProd = process.env.VERCEL_ENV === 'production' || process.env.NODE_ENV === 'production';
+
+function secret() {
+  const s = process.env.SESSION_SECRET;
+  if (!s) {
+    console.warn('SESSION_SECRET not set - using an insecure local-dev default. Set a real secret in production.');
+    return 'local-dev-insecure-secret';
+  }
+  return s;
+}
+
+function sign(value) {
+  const h = crypto.createHmac('sha256', secret()).update(value).digest('base64url');
+  return `${value}.${h}`;
+}
+
+function verify(signed) {
+  if (!signed) return null;
+  const idx = signed.lastIndexOf('.');
+  if (idx === -1) return null;
+  const value = signed.slice(0, idx);
+  if (sign(value) !== signed) return null;
+  return value;
+}
+
+export function issueSessionCookie(res, email) {
+  const token = encodeURIComponent(sign(email));
+  res.setHeader(
+    'Set-Cookie',
+    `${COOKIE_NAME}=${token}; Max-Age=${MAX_AGE_SECONDS}; Path=/; HttpOnly; SameSite=Lax${isProd ? '; Secure' : ''}`
+  );
+}
+
+export function clearSessionCookie(res) {
+  res.setHeader('Set-Cookie', `${COOKIE_NAME}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax${isProd ? '; Secure' : ''}`);
+}
+
+export function readSessionEmail(req) {
+  const header = req.headers.cookie || '';
+  const match = header
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${COOKIE_NAME}=`));
+  if (!match) return null;
+  return verify(decodeURIComponent(match.slice(COOKIE_NAME.length + 1)));
+}

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,0 +1,29 @@
+import { findOrCreateUser } from '../_lib/db.js';
+import { issueSessionCookie } from '../_lib/session.js';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+
+  const email = String(req.body?.email || '')
+    .trim()
+    .toLowerCase();
+
+  if (!EMAIL_RE.test(email)) {
+    res.status(400).json({ message: 'Please enter a valid email address.' });
+    return;
+  }
+
+  try {
+    const user = await findOrCreateUser(email);
+    issueSessionCookie(res, user.email);
+    res.status(200).json({ user: { email: user.email } });
+  } catch (err) {
+    console.error('auth/login error:', err);
+    res.status(500).json({ message: 'Could not sign you in right now. Please try again.' });
+  }
+}

--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -1,0 +1,10 @@
+import { clearSessionCookie } from '../_lib/session.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+  clearSessionCookie(res);
+  res.status(200).json({ ok: true });
+}

--- a/api/auth/me.js
+++ b/api/auth/me.js
@@ -1,0 +1,18 @@
+import { getUserByEmail } from '../_lib/db.js';
+import { readSessionEmail } from '../_lib/session.js';
+
+export default async function handler(req, res) {
+  const email = readSessionEmail(req);
+  if (!email) {
+    res.status(200).json({ user: null });
+    return;
+  }
+
+  try {
+    const user = await getUserByEmail(email);
+    res.status(200).json({ user: user ? { email: user.email } : null });
+  } catch (err) {
+    console.error('auth/me error:', err);
+    res.status(200).json({ user: null });
+  }
+}

--- a/api/recipe-book.js
+++ b/api/recipe-book.js
@@ -1,0 +1,56 @@
+import { getUserByEmail, listSavedRecipes, saveRecipe, deleteRecipe } from './_lib/db.js';
+import { readSessionEmail } from './_lib/session.js';
+
+async function requireUser(req, res) {
+  const email = readSessionEmail(req);
+  if (!email) {
+    res.status(401).json({ message: 'Please log in to manage your recipe book.' });
+    return null;
+  }
+  const user = await getUserByEmail(email);
+  if (!user) {
+    res.status(401).json({ message: 'Please log in to manage your recipe book.' });
+    return null;
+  }
+  return user;
+}
+
+export default async function handler(req, res) {
+  try {
+    const user = await requireUser(req, res);
+    if (!user) return;
+
+    if (req.method === 'GET') {
+      const recipes = await listSavedRecipes(user.id);
+      res.status(200).json({ recipes });
+      return;
+    }
+
+    if (req.method === 'POST') {
+      const { title, isHealthy, ingredients, instructions } = req.body || {};
+      if (!title || !ingredients || !instructions) {
+        res.status(400).json({ message: 'Missing recipe fields.' });
+        return;
+      }
+      const recipe = await saveRecipe(user.id, { title, isHealthy, ingredients, instructions });
+      res.status(200).json({ recipe });
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      const id = Number(req.query?.id);
+      if (!id) {
+        res.status(400).json({ message: 'Missing recipe id.' });
+        return;
+      }
+      await deleteRecipe(user.id, id);
+      res.status(200).json({ ok: true });
+      return;
+    }
+
+    res.status(405).json({ message: 'Method not allowed' });
+  } catch (err) {
+    console.error('recipe-book handler error:', err);
+    res.status(500).json({ message: 'Something went wrong. Please try again.' });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,37 @@
       "name": "leftover-to-recipe",
       "version": "1.0.0",
       "dependencies": {
+        "@neondatabase/serverless": "^0.10.4",
         "@upstash/redis": "^1.38.2"
+      }
+    },
+    "node_modules/@neondatabase/serverless": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.10.4.tgz",
+      "integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "8.11.6"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
       }
     },
     "node_modules/@upstash/redis": {
@@ -20,10 +50,109 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.1.0.tgz",
+      "integrity": "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "license": "MIT"
+    },
     "node_modules/uncrypto": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Serverless API functions (used by Vercel for the /api endpoints). See web/ for the React frontend.",
   "dependencies": {
+    "@neondatabase/serverless": "^0.10.4",
     "@upstash/redis": "^1.38.2"
   }
 }

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -9,6 +9,7 @@ import Camera from './steps/Camera.jsx';
 import Ingredients from './steps/Ingredients.jsx';
 import RecipeList from './steps/RecipeList.jsx';
 import RecipeDetail from './steps/RecipeDetail.jsx';
+import MyRecipes from './steps/MyRecipes.jsx';
 import { fetchIngredients, fetchRecipes } from './api.js';
 
 const STEP = {
@@ -17,7 +18,8 @@ const STEP = {
   CAMERA: 'camera',
   INGREDIENTS: 'ingredients',
   RECIPES: 'recipes',
-  RECIPE_DETAIL: 'recipe_detail'
+  RECIPE_DETAIL: 'recipe_detail',
+  MY_RECIPES: 'my_recipes'
 };
 
 // Maps app steps to the 4-dot progress indicator shown above each screen.
@@ -101,16 +103,22 @@ export default function App() {
       ingredients: recipe.Ingredients,
       instructions: recipe.Instructions
     });
-    setSuccessMessage('Congratulations! This recipe has been added to your recipe book.');
+    setSuccessMessage('Here’s your recipe! Hit "Save" to keep it in your recipe book.');
+    setStep(STEP.RECIPE_DETAIL);
+  }
+
+  function handleViewSavedRecipe(recipe) {
+    setSelectedRecipe(recipe);
+    setSuccessMessage('');
     setStep(STEP.RECIPE_DETAIL);
   }
 
   return (
     <div className="app-shell">
-      <Navbar onNavigateHome={goHome} />
+      <Navbar onNavigateHome={goHome} onNavigateRecipeBook={() => setStep(STEP.MY_RECIPES)} />
 
       <div className="page-container app-main" style={{ paddingBottom: 'var(--space-8)' }}>
-        {step !== STEP.HOME && <StepIndicator current={STEP_INDEX[step]} />}
+        {step in STEP_INDEX && <StepIndicator current={STEP_INDEX[step]} />}
 
         {step !== STEP.CAMERA && step !== STEP.INGREDIENTS && (
           <>
@@ -171,6 +179,8 @@ export default function App() {
         {step === STEP.RECIPE_DETAIL && selectedRecipe && (
           <RecipeDetail recipe={selectedRecipe} onGenerateNew={() => setStep(STEP.CAMERA)} onBackHome={goHome} />
         )}
+
+        {step === STEP.MY_RECIPES && <MyRecipes onBack={goHome} onView={handleViewSavedRecipe} />}
       </div>
 
       <Footer />

--- a/web/src/AuthContext.jsx
+++ b/web/src/AuthContext.jsx
@@ -1,0 +1,35 @@
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { fetchMe, login as loginRequest, logout as logoutRequest } from './api.js';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchMe()
+      .then((data) => setUser(data.user))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const login = useCallback(async (email) => {
+    const data = await loginRequest(email);
+    setUser(data.user);
+    return data.user;
+  }, []);
+
+  const logout = useCallback(async () => {
+    await logoutRequest();
+    setUser(null);
+  }, []);
+
+  return <AuthContext.Provider value={{ user, loading, login, logout }}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider');
+  return ctx;
+}

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -3,11 +3,11 @@
 // (demo limit) case gets the same treatment as any other failure, so the
 // UI never has to special-case it beyond reading the message.
 
-async function postJSON(url, body) {
+async function request(url, options = {}) {
   const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
+    credentials: 'include',
+    headers: options.body ? { 'Content-Type': 'application/json' } : undefined,
+    ...options
   });
 
   const data = await response.json().catch(() => ({}));
@@ -19,10 +19,42 @@ async function postJSON(url, body) {
   return data;
 }
 
+function postJSON(url, body) {
+  return request(url, { method: 'POST', body: JSON.stringify(body) });
+}
+
 export function fetchIngredients({ imageBase64, personPreferences, personAllergies }) {
   return postJSON('/api/ingredients', { imageBase64, personPreferences, personAllergies });
 }
 
 export function fetchRecipes({ ingredients, personPreferences, personAllergies }) {
   return postJSON('/api/recipes', { ingredients, personPreferences, personAllergies });
+}
+
+// ---- Auth ----
+
+export function fetchMe() {
+  return request('/api/auth/me');
+}
+
+export function login(email) {
+  return postJSON('/api/auth/login', { email });
+}
+
+export function logout() {
+  return request('/api/auth/logout', { method: 'POST' });
+}
+
+// ---- Recipe book ----
+
+export function fetchRecipeBook() {
+  return request('/api/recipe-book');
+}
+
+export function saveToRecipeBook(recipe) {
+  return postJSON('/api/recipe-book', recipe);
+}
+
+export function removeFromRecipeBook(id) {
+  return request(`/api/recipe-book?id=${id}`, { method: 'DELETE' });
 }

--- a/web/src/components/Icon.jsx
+++ b/web/src/components/Icon.jsx
@@ -12,7 +12,12 @@ const paths = {
     'M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2ZM12 17a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z',
   edit: 'M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4Z',
   menu: 'M4 6h16M4 12h16M4 18h16',
-  home: 'M3 9.5 12 3l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1Z'
+  home: 'M3 9.5 12 3l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1Z',
+  user: 'M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2M12 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z',
+  bookmark: 'M19 21 12 16l-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2Z',
+  download: 'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3',
+  logout: 'M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9',
+  trash: 'M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0-1 14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2L4 6h16Z'
 };
 
 export default function Icon({ name, size = 20, strokeWidth = 2, className = '', style }) {

--- a/web/src/components/LoginModal.jsx
+++ b/web/src/components/LoginModal.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import Icon from './Icon.jsx';
+import { useAuth } from '../AuthContext.jsx';
+
+export default function LoginModal({ onClose, onLoggedIn }) {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError('');
+    setIsSubmitting(true);
+    try {
+      await login(email.trim());
+      onLoggedIn?.();
+      onClose();
+    } catch (err) {
+      setError(err.message || 'Could not log in. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal-panel" onClick={(e) => e.stopPropagation()}>
+        <button type="button" className="modal-close" aria-label="Close" onClick={onClose}>
+          <Icon name="x" size={18} />
+        </button>
+
+        <div className="icon-circle" style={{ margin: '0 auto var(--space-3)', width: 48, height: 48 }}>
+          <Icon name="user" size={22} />
+        </div>
+
+        <h3>Log in to save recipes</h3>
+        <p className="profile-meta" style={{ marginBottom: 'var(--space-4)' }}>
+          Enter your email — no password needed. We'll keep your recipe book under this address.
+        </p>
+
+        <form onSubmit={handleSubmit} style={{ textAlign: 'left' }}>
+          <label className="form-label" htmlFor="login-email">
+            Email
+          </label>
+          <input
+            id="login-email"
+            type="email"
+            required
+            autoFocus
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="form-input"
+          />
+
+          {error && (
+            <p className="profile-meta" style={{ color: 'var(--color-danger)', marginTop: 'var(--space-2)' }}>
+              {error}
+            </p>
+          )}
+
+          <button type="submit" className="btn btn-primary btn-block" disabled={isSubmitting}>
+            {isSubmitting ? 'Logging in…' : 'Continue'}
+          </button>
+        </form>
+
+        <p className="profile-meta" style={{ marginTop: 'var(--space-3)', fontSize: 12 }}>
+          Demo login: this only checks that it looks like an email, no verification email is sent. Don't reuse a
+          sensitive password-protected account here.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Navbar.jsx
+++ b/web/src/components/Navbar.jsx
@@ -1,6 +1,18 @@
+import { useState } from 'react';
 import Icon from './Icon.jsx';
+import LoginModal from './LoginModal.jsx';
+import { useAuth } from '../AuthContext.jsx';
 
-export default function Navbar({ onNavigateHome }) {
+export default function Navbar({ onNavigateHome, onNavigateRecipeBook }) {
+  const { user, loading, logout } = useAuth();
+  const [showLogin, setShowLogin] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+
+  async function handleLogout() {
+    setShowMenu(false);
+    await logout();
+  }
+
   return (
     <header className="navbar">
       <div className="page-container navbar-inner">
@@ -18,11 +30,56 @@ export default function Navbar({ onNavigateHome }) {
           <span className="navbar-title">Leftover to Recipe</span>
         </a>
 
-        <button type="button" className="navbar-home-btn" onClick={onNavigateHome}>
-          <Icon name="home" size={16} />
-          Home
-        </button>
+        <div className="navbar-actions">
+          <button type="button" className="navbar-home-btn" onClick={onNavigateHome}>
+            <Icon name="home" size={16} />
+            Home
+          </button>
+
+          {!loading && !user && (
+            <button type="button" className="navbar-profile-btn" onClick={() => setShowLogin(true)} aria-label="Log in">
+              <Icon name="user" size={18} />
+            </button>
+          )}
+
+          {!loading && user && (
+            <div className="navbar-profile-menu">
+              <button
+                type="button"
+                className="navbar-profile-btn navbar-profile-btn-active"
+                onClick={() => setShowMenu((v) => !v)}
+                aria-label="Account menu"
+              >
+                {user.email[0].toUpperCase()}
+              </button>
+
+              {showMenu && (
+                <>
+                  <div className="navbar-menu-backdrop" onClick={() => setShowMenu(false)} />
+                  <div className="navbar-dropdown">
+                    <p className="navbar-dropdown-email">{user.email}</p>
+                    <button
+                      type="button"
+                      className="navbar-dropdown-item"
+                      onClick={() => {
+                        setShowMenu(false);
+                        onNavigateRecipeBook();
+                      }}
+                    >
+                      <Icon name="bookmark" size={16} /> My recipe book
+                    </button>
+                    <button type="button" className="navbar-dropdown-item" onClick={handleLogout}>
+                      <Icon name="logout" size={16} /> Log out
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
       </div>
+
+      {showLogin && <LoginModal onClose={() => setShowLogin(false)} />}
     </header>
   );
 }

--- a/web/src/components/ShareModal.jsx
+++ b/web/src/components/ShareModal.jsx
@@ -1,0 +1,263 @@
+import { useEffect, useRef, useState } from 'react';
+import Icon from './Icon.jsx';
+
+// Set this once the app is live on the Play Store - shown as a CTA on the
+// generated share image and used by the "Get the app" button below.
+// Leave blank to hide both until the listing is ready.
+const PLAY_STORE_URL = import.meta.env.VITE_PLAY_STORE_URL || '';
+const SITE_URL = import.meta.env.VITE_SITE_URL || 'https://leftover-to-recipe.vercel.app';
+
+const CARD_W = 1080;
+const CARD_H = 1350; // 4:5, plays nicely as an IG/FB feed post and a WhatsApp/Messenger attachment
+
+function wrapText(ctx, text, maxWidth) {
+  const words = text.split(' ');
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    const test = line ? `${line} ${word}` : word;
+    if (ctx.measureText(test).width > maxWidth && line) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = test;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+}
+
+async function renderCard(recipe) {
+  const canvas = document.createElement('canvas');
+  canvas.width = CARD_W;
+  canvas.height = CARD_H;
+  const ctx = canvas.getContext('2d');
+
+  // Background
+  const bg = ctx.createLinearGradient(0, 0, 0, CARD_H);
+  bg.addColorStop(0, '#e5f5eb');
+  bg.addColorStop(1, '#faf9f6');
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, CARD_W, CARD_H);
+
+  const pad = 72;
+  let y = 100;
+
+  // Brand row
+  ctx.font = '64px system-ui, sans-serif';
+  ctx.textBaseline = 'alphabetic';
+  ctx.fillText('🍲', pad, y);
+  ctx.fillStyle = '#217a46';
+  ctx.font = '600 40px Georgia, serif';
+  ctx.fillText('Leftover to Recipe', pad + 88, y - 8);
+  y += 70;
+
+  // Badge
+  ctx.fillStyle = recipe.isHealthy ? '#2f9e5c' : '#e05f2c';
+  const badgeText = recipe.isHealthy ? '🥦 Healthy' : '🍩 Relax';
+  ctx.font = '600 30px system-ui, sans-serif';
+  const badgeW = ctx.measureText(badgeText).width + 48;
+  ctx.beginPath();
+  ctx.roundRect(pad, y, badgeW, 56, 28);
+  ctx.fill();
+  ctx.fillStyle = '#ffffff';
+  ctx.fillText(badgeText, pad + 24, y + 38);
+  y += 110;
+
+  // Title
+  ctx.fillStyle = '#1f2a24';
+  ctx.font = '700 60px Georgia, serif';
+  const titleLines = wrapText(ctx, recipe.title, CARD_W - pad * 2);
+  for (const line of titleLines.slice(0, 3)) {
+    ctx.fillText(line, pad, y);
+    y += 68;
+  }
+  y += 24;
+
+  // Divider
+  ctx.strokeStyle = '#e8e4da';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(pad, y);
+  ctx.lineTo(CARD_W - pad, y);
+  ctx.stroke();
+  y += 56;
+
+  // Ingredients heading
+  ctx.fillStyle = '#217a46';
+  ctx.font = '700 34px system-ui, sans-serif';
+  ctx.fillText('Ingredients', pad, y);
+  y += 50;
+
+  ctx.fillStyle = '#1f2a24';
+  ctx.font = '32px system-ui, sans-serif';
+  const shown = recipe.ingredients.slice(0, 8);
+  for (const ingredient of shown) {
+    const lines = wrapText(ctx, `•  ${ingredient}`, CARD_W - pad * 2);
+    for (const line of lines) {
+      if (y > CARD_H - 220) break;
+      ctx.fillText(line, pad, y);
+      y += 46;
+    }
+  }
+  if (recipe.ingredients.length > shown.length) {
+    ctx.fillStyle = '#6b7568';
+    ctx.fillText(`+ ${recipe.ingredients.length - shown.length} more…`, pad, y);
+    y += 46;
+  }
+
+  // Footer CTA
+  ctx.fillStyle = '#217a46';
+  ctx.fillRect(0, CARD_H - 140, CARD_W, 140);
+  ctx.fillStyle = '#ffffff';
+  ctx.font = '600 32px system-ui, sans-serif';
+  ctx.fillText('Turn your leftovers into a recipe 🍜', pad, CARD_H - 78);
+  ctx.font = '28px system-ui, sans-serif';
+  ctx.fillStyle = '#e5f5eb';
+  ctx.fillText(PLAY_STORE_URL ? 'Get the app on Google Play' : SITE_URL.replace(/^https?:\/\//, ''), pad, CARD_H - 36);
+
+  return new Promise((resolve) => canvas.toBlob((blob) => resolve({ blob, canvas }), 'image/png'));
+}
+
+export default function ShareModal({ recipe, onClose }) {
+  const [imageUrl, setImageUrl] = useState('');
+  const [blob, setBlob] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const objectUrlRef = useRef('');
+
+  useEffect(() => {
+    let cancelled = false;
+    renderCard(recipe).then(({ blob: b }) => {
+      if (cancelled) return;
+      const url = URL.createObjectURL(b);
+      objectUrlRef.current = url;
+      setBlob(b);
+      setImageUrl(url);
+    });
+    return () => {
+      cancelled = true;
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const shareText = `${recipe.title} — made from my leftovers with Leftover to Recipe! ${SITE_URL}`;
+  const canNativeShare =
+    typeof navigator !== 'undefined' &&
+    navigator.canShare &&
+    blob &&
+    navigator.canShare({ files: [new File([blob], 'recipe.png', { type: 'image/png' })] });
+
+  async function handleNativeShare() {
+    try {
+      const file = new File([blob], `${recipe.title.replace(/\s+/g, '-').toLowerCase()}.png`, { type: 'image/png' });
+      await navigator.share({
+        title: recipe.title,
+        text: shareText,
+        files: [file]
+      });
+    } catch (err) {
+      // User cancelled the share sheet, or the browser rejected it - not an error worth showing.
+      if (err?.name !== 'AbortError') {
+        console.error('share failed:', err);
+      }
+    }
+  }
+
+  function handleDownload() {
+    if (!imageUrl) return;
+    const a = document.createElement('a');
+    a.href = imageUrl;
+    a.download = `${recipe.title.replace(/\s+/g, '-').toLowerCase()}.png`;
+    a.click();
+  }
+
+  async function handleCopyCaption() {
+    try {
+      await navigator.clipboard.writeText(shareText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard API unavailable - non-fatal, the caption is shown on screen too
+    }
+  }
+
+  const webIntents = [
+    {
+      name: 'Facebook',
+      emoji: '📘',
+      url: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(SITE_URL)}&quote=${encodeURIComponent(shareText)}`
+    },
+    {
+      name: 'Messenger',
+      emoji: '💬',
+      url: `https://www.facebook.com/dialog/send?link=${encodeURIComponent(SITE_URL)}&app_id=&redirect_uri=${encodeURIComponent(SITE_URL)}`
+    },
+    {
+      name: 'WhatsApp',
+      emoji: '🟢',
+      url: `https://wa.me/?text=${encodeURIComponent(shareText)}`
+    }
+  ];
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal-panel share-modal" onClick={(e) => e.stopPropagation()}>
+        <button type="button" className="modal-close" aria-label="Close" onClick={onClose}>
+          <Icon name="x" size={18} />
+        </button>
+
+        <h3>Share this recipe</h3>
+        <p className="profile-meta" style={{ marginBottom: 'var(--space-4)' }}>
+          A shareable image is generated below with the recipe, ready for socials.
+        </p>
+
+        <div className="share-preview">
+          {imageUrl ? <img src={imageUrl} alt={`${recipe.title} recipe card`} /> : <div className="share-preview-loading">Generating image…</div>}
+        </div>
+
+        {canNativeShare && (
+          <button type="button" className="btn btn-primary btn-block" onClick={handleNativeShare}>
+            <Icon name="share" size={16} /> Share to Instagram, WhatsApp, Messenger…
+          </button>
+        )}
+
+        <button type="button" className="btn btn-secondary btn-block" onClick={handleDownload} disabled={!imageUrl}>
+          <Icon name="download" size={16} /> Download image
+        </button>
+
+        {!canNativeShare && (
+          <>
+            <p className="profile-meta" style={{ marginTop: 'var(--space-4)', marginBottom: 'var(--space-2)' }}>
+              Your browser doesn't support the native share sheet — post directly instead, or download the image
+              above and attach it to Instagram or WhatsApp manually.
+            </p>
+            <div className="share-intent-row">
+              {webIntents.map((intent) => (
+                <a
+                  key={intent.name}
+                  className="btn btn-outline btn-sm"
+                  href={intent.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {intent.emoji} {intent.name}
+                </a>
+              ))}
+            </div>
+          </>
+        )}
+
+        <button type="button" className="link-back" style={{ marginTop: 'var(--space-4)' }} onClick={handleCopyCaption}>
+          {copied ? 'Caption copied ✓' : 'Copy caption text'}
+        </button>
+
+        {PLAY_STORE_URL && (
+          <a href={PLAY_STORE_URL} target="_blank" rel="noopener noreferrer" className="profile-meta" style={{ display: 'block', marginTop: 'var(--space-2)' }}>
+            Get Leftover to Recipe on Google Play →
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -956,3 +956,180 @@ input[type='email']:focus {
     font-size: 40px;
   }
 }
+
+/* ---------- Navbar: account / profile ---------- */
+
+.navbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.navbar-profile-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-surface-sunken);
+  color: var(--color-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.navbar-profile-btn:hover {
+  background: var(--color-border);
+}
+
+.navbar-profile-btn-active {
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+}
+.navbar-profile-btn-active:hover {
+  background: var(--color-primary-dark);
+}
+
+.navbar-profile-menu {
+  position: relative;
+}
+
+.navbar-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 199;
+}
+
+.navbar-dropdown {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  z-index: 200;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  min-width: 220px;
+  padding: var(--space-2);
+}
+
+.navbar-dropdown-email {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  padding: var(--space-2) var(--space-3);
+  margin: 0 0 var(--space-1);
+  border-bottom: 1px solid var(--color-border);
+  word-break: break-all;
+}
+
+.navbar-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+  cursor: pointer;
+}
+.navbar-dropdown-item:hover {
+  background: var(--color-surface-sunken);
+}
+
+/* ---------- Modal close button ---------- */
+
+.modal-close {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-surface-sunken);
+  color: var(--color-text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.modal-close:hover {
+  background: var(--color-border);
+  color: var(--color-text);
+}
+
+.modal-panel {
+  position: relative;
+}
+
+/* ---------- Form fields (login modal) ---------- */
+
+.form-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-1);
+}
+
+.form-input {
+  width: 100%;
+  border: 1.5px solid var(--color-border) !important;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-sunken) !important;
+  padding: 10px 14px !important;
+  font-size: 15px;
+  margin-bottom: var(--space-3);
+}
+.form-input:focus {
+  border-color: var(--color-primary) !important;
+  outline: none;
+}
+
+/* ---------- Share modal ---------- */
+
+.share-modal {
+  max-width: 380px;
+}
+
+.share-preview {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  margin-bottom: var(--space-4);
+  background: var(--color-surface-sunken);
+}
+
+.share-preview img {
+  width: 100%;
+  display: block;
+}
+
+.share-preview-loading {
+  aspect-ratio: 4 / 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: 14px;
+}
+
+.share-modal .btn-block {
+  margin-top: var(--space-2);
+}
+
+.share-intent-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: center;
+  margin-top: var(--space-2);
+}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import { AuthProvider } from './AuthContext.jsx';
 import './main.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/web/src/steps/MyRecipes.jsx
+++ b/web/src/steps/MyRecipes.jsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import Icon from '../components/Icon.jsx';
+import { fetchRecipeBook, removeFromRecipeBook } from '../api.js';
+
+export default function MyRecipes({ onBack, onView }) {
+  const [recipes, setRecipes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetchRecipeBook()
+      .then((data) => setRecipes(data.recipes || []))
+      .catch((err) => setError(err.message || 'Could not load your recipe book.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleDelete(id) {
+    setRecipes((prev) => prev.filter((r) => r.id !== id));
+    try {
+      await removeFromRecipeBook(id);
+    } catch (err) {
+      setError(err.message || 'Could not remove that recipe.');
+    }
+  }
+
+  return (
+    <>
+      <button type="button" className="link-back" onClick={onBack}>
+        <Icon name="arrowLeft" size={16} /> Back
+      </button>
+
+      <h2 style={{ marginTop: 'var(--space-4)' }}>My recipe book</h2>
+      <p className="profile-meta" style={{ marginBottom: 'var(--space-4)' }}>
+        Recipes you've saved, kept under your account.
+      </p>
+
+      {error && (
+        <p className="profile-meta" style={{ color: 'var(--color-danger)' }}>
+          {error}
+        </p>
+      )}
+
+      {loading && <p className="profile-meta">Loading…</p>}
+
+      {!loading && recipes.length === 0 && !error && (
+        <div className="card card-padded" style={{ textAlign: 'center' }}>
+          <p className="profile-meta">No saved recipes yet — generate one and hit "Save to my recipe book".</p>
+        </div>
+      )}
+
+      <div className="recipe-grid">
+        {recipes.map((recipe) => (
+          <div key={recipe.id} className="recipe-card">
+            <div className="recipe-card-header">
+              <h4>{recipe.title}</h4>
+              <span className={`badge ${recipe.isHealthy ? 'badge-primary' : 'badge-accent'}`}>
+                {recipe.isHealthy ? '🥦 Healthy' : '🍩 Relax'}
+              </span>
+            </div>
+            <p className="recipe-card-summary">{recipe.ingredients.slice(0, 4).join(', ')}…</p>
+            <div className="cta-group" style={{ marginTop: 'var(--space-3)' }}>
+              <button type="button" className="btn btn-sm btn-primary" onClick={() => onView(recipe)}>
+                View
+              </button>
+              <button type="button" className="btn btn-sm btn-outline" onClick={() => handleDelete(recipe.id)}>
+                <Icon name="trash" size={14} /> Remove
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/web/src/steps/RecipeDetail.jsx
+++ b/web/src/steps/RecipeDetail.jsx
@@ -1,13 +1,39 @@
 import { useState } from 'react';
 import Icon from '../components/Icon.jsx';
+import ShareModal from '../components/ShareModal.jsx';
+import LoginModal from '../components/LoginModal.jsx';
+import { saveToRecipeBook } from '../api.js';
 
 export default function RecipeDetail({ recipe, onGenerateNew, onBackHome }) {
   const [rating, setRating] = useState(0);
   const [showThankYou, setShowThankYou] = useState(false);
+  const [showShare, setShowShare] = useState(false);
+  const [showLogin, setShowLogin] = useState(false);
+  const [saveState, setSaveState] = useState('idle'); // idle | saving | saved | error
+  const [saveError, setSaveError] = useState('');
 
   function handleRate(value) {
     setRating(value);
     setShowThankYou(true);
+  }
+
+  async function handleSave() {
+    setSaveState('saving');
+    setSaveError('');
+    try {
+      await saveToRecipeBook(recipe);
+      setSaveState('saved');
+    } catch (err) {
+      // The API responds 401 with this message when there's no session -
+      // prompt login instead of surfacing it as a hard error.
+      if (err.message?.toLowerCase().includes('log in')) {
+        setSaveState('idle');
+        setShowLogin(true);
+      } else {
+        setSaveState('error');
+        setSaveError(err.message || 'Could not save this recipe.');
+      }
+    }
   }
 
   return (
@@ -19,13 +45,30 @@ export default function RecipeDetail({ recipe, onGenerateNew, onBackHome }) {
       <div className="card card-padded" style={{ marginTop: 'var(--space-4)' }}>
         <div className="recipe-card-header">
           <h2 style={{ marginBottom: 0 }}>{recipe.title}</h2>
-          <button type="button" className="btn btn-sm btn-secondary" style={{ flexShrink: 0 }}>
-            <Icon name="share" size={15} /> Share
-          </button>
+          <div style={{ display: 'flex', gap: 'var(--space-2)', flexShrink: 0 }}>
+            <button type="button" className="btn btn-sm btn-secondary" onClick={() => setShowShare(true)}>
+              <Icon name="share" size={15} /> Share
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm btn-outline"
+              onClick={handleSave}
+              disabled={saveState === 'saving' || saveState === 'saved'}
+            >
+              <Icon name="bookmark" size={15} />
+              {saveState === 'saved' ? 'Saved' : saveState === 'saving' ? 'Saving…' : 'Save'}
+            </button>
+          </div>
         </div>
         <span className={`badge ${recipe.isHealthy ? 'badge-primary' : 'badge-accent'}`} style={{ marginBottom: 'var(--space-4)' }}>
           {recipe.isHealthy ? '🥦 Healthy' : '🍩 Relax'}
         </span>
+
+        {saveError && (
+          <p className="profile-meta" style={{ color: 'var(--color-danger)', marginBottom: 'var(--space-3)' }}>
+            {saveError}
+          </p>
+        )}
 
         <h4>Ingredients</h4>
         <ul className="recipe-list">
@@ -71,6 +114,10 @@ export default function RecipeDetail({ recipe, onGenerateNew, onBackHome }) {
           </div>
         </div>
       )}
+
+      {showShare && <ShareModal recipe={recipe} onClose={() => setShowShare(false)} />}
+
+      {showLogin && <LoginModal onClose={() => setShowLogin(false)} onLoggedIn={handleSave} />}
     </>
   );
 }


### PR DESCRIPTION
Add email login, personal recipe book, and social share

- Login: email-only passwordless login (signed httpOnly cookie),
  profile icon + account dropdown in the navbar
- Recipe book: Save/My recipe book backed by Neon Postgres
  (api/_lib/db.js), with an in-memory fallback for quick local UI
  checks (not reliable across requests without DATABASE_URL)
- Share: RecipeDetail's Share button now generates a branded
  recipe card image client-side (canvas) and offers the native
  Web Share sheet (Instagram, WhatsApp, Messenger, etc via the OS
  share sheet) with a download + Facebook/Messenger/WhatsApp
  web-intent fallback for browsers without native share support
- New env vars: DATABASE_URL (Neon), SESSION_SECRET, optional
  VITE_PLAY_STORE_URL / VITE_SITE_URL - documented in README

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
