### PR TITLE
Fix share image/save UX, add public share links

### DIFF
--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -36,6 +36,20 @@ async function getSql() {
           created_at TIMESTAMPTZ DEFAULT now()
         )
       `;
+      // Public, unauthenticated snapshot of a recipe - created when someone
+      // hits Share, so the "share this recipe" link works for anyone,
+      // logged in or not. Deliberately separate from saved_recipes (which is
+      // private to one account).
+      await sql`
+        CREATE TABLE IF NOT EXISTS shared_recipes (
+          id SERIAL PRIMARY KEY,
+          title TEXT NOT NULL,
+          is_healthy BOOLEAN NOT NULL DEFAULT false,
+          ingredients JSONB NOT NULL,
+          instructions JSONB NOT NULL,
+          created_at TIMESTAMPTZ DEFAULT now()
+        )
+      `;
       return sql;
     })();
   }
@@ -46,8 +60,10 @@ async function getSql() {
 
 const memUsers = new Map(); // email -> user
 const memRecipes = new Map(); // userId -> recipe[]
+const memSharedRecipes = new Map(); // id -> recipe
 let memNextUserId = 1;
 let memNextRecipeId = 1;
+let memNextSharedRecipeId = 1;
 
 // ---------------- public API ----------------
 
@@ -125,6 +141,41 @@ export async function deleteRecipe(userId, recipeId) {
     userId,
     list.filter((r) => r.id !== recipeId)
   );
+}
+
+export async function createSharedRecipe(recipe) {
+  const { title, isHealthy, ingredients, instructions } = recipe;
+  if (hasDb) {
+    const sql = await getSql();
+    const rows = await sql`
+      INSERT INTO shared_recipes (title, is_healthy, ingredients, instructions)
+      VALUES (${title}, ${!!isHealthy}, ${JSON.stringify(ingredients)}::jsonb, ${JSON.stringify(instructions)}::jsonb)
+      RETURNING id, title, is_healthy AS "isHealthy", ingredients, instructions, created_at AS "createdAt"
+    `;
+    return rows[0];
+  }
+  const saved = {
+    id: memNextSharedRecipeId++,
+    title,
+    isHealthy: !!isHealthy,
+    ingredients,
+    instructions,
+    createdAt: new Date().toISOString()
+  };
+  memSharedRecipes.set(saved.id, saved);
+  return saved;
+}
+
+export async function getSharedRecipeById(id) {
+  if (hasDb) {
+    const sql = await getSql();
+    const rows = await sql`
+      SELECT id, title, is_healthy AS "isHealthy", ingredients, instructions, created_at AS "createdAt"
+      FROM shared_recipes WHERE id = ${id}
+    `;
+    return rows[0] || null;
+  }
+  return memSharedRecipes.get(id) || null;
 }
 
 export const usingRealDatabase = hasDb;

--- a/api/share.js
+++ b/api/share.js
@@ -1,0 +1,40 @@
+// Public share links: no login required, either to create one (POST) or
+// to open one (GET) - anyone with the link can view that recipe. Backed by
+// shared_recipes, a separate table from each user's private saved_recipes.
+
+import { createSharedRecipe, getSharedRecipeById } from './_lib/db.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'POST') {
+      const { title, isHealthy, ingredients, instructions } = req.body || {};
+      if (!title || !ingredients || !instructions) {
+        res.status(400).json({ message: 'Missing recipe fields.' });
+        return;
+      }
+      const recipe = await createSharedRecipe({ title, isHealthy, ingredients, instructions });
+      res.status(200).json({ id: recipe.id });
+      return;
+    }
+
+    if (req.method === 'GET') {
+      const id = Number(req.query?.id);
+      if (!id) {
+        res.status(400).json({ message: 'Missing recipe id.' });
+        return;
+      }
+      const recipe = await getSharedRecipeById(id);
+      if (!recipe) {
+        res.status(404).json({ message: 'This shared recipe could not be found.' });
+        return;
+      }
+      res.status(200).json({ recipe });
+      return;
+    }
+
+    res.status(405).json({ message: 'Method not allowed' });
+  } catch (err) {
+    console.error('share handler error:', err);
+    res.status(500).json({ message: 'Something went wrong. Please try again.' });
+  }
+}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Navbar from './components/Navbar.jsx';
 import Footer from './components/Footer.jsx';
 import FlashMessage from './components/FlashMessage.jsx';
@@ -10,7 +10,7 @@ import Ingredients from './steps/Ingredients.jsx';
 import RecipeList from './steps/RecipeList.jsx';
 import RecipeDetail from './steps/RecipeDetail.jsx';
 import MyRecipes from './steps/MyRecipes.jsx';
-import { fetchIngredients, fetchRecipes } from './api.js';
+import { fetchIngredients, fetchRecipes, fetchSharedRecipe } from './api.js';
 
 const STEP = {
   HOME: 'home',
@@ -19,8 +19,13 @@ const STEP = {
   INGREDIENTS: 'ingredients',
   RECIPES: 'recipes',
   RECIPE_DETAIL: 'recipe_detail',
-  MY_RECIPES: 'my_recipes'
+  MY_RECIPES: 'my_recipes',
+  // A recipe opened from someone else's share link (/r/:id) - no step
+  // progress dots shown, since this visitor didn't go through the flow.
+  SHARED_RECIPE: 'shared_recipe'
 };
+
+const SHARE_LINK_PATH = /^\/r\/(\d+)$/;
 
 // Maps app steps to the 4-dot progress indicator shown above each screen.
 // HOME has no entry - the landing page doesn't show step progress.
@@ -44,11 +49,34 @@ export default function App() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const [sharedLinkError, setSharedLinkError] = useState('');
+  const [loadingSharedRecipe, setLoadingSharedRecipe] = useState(() => SHARE_LINK_PATH.test(window.location.pathname));
+
+  // On first load, if the URL is a share link (/r/:id), fetch that recipe
+  // and jump straight to it instead of the landing page.
+  useEffect(() => {
+    const match = window.location.pathname.match(SHARE_LINK_PATH);
+    if (!match) return;
+    fetchSharedRecipe(match[1])
+      .then((data) => {
+        setSelectedRecipe(data.recipe);
+        setStep(STEP.SHARED_RECIPE);
+      })
+      .catch((err) => {
+        setSharedLinkError(err.message || 'This shared recipe could not be found.');
+        window.history.replaceState({}, '', '/');
+      })
+      .finally(() => setLoadingSharedRecipe(false));
+  }, []);
 
   function goHome() {
     setStep(STEP.HOME);
     setErrorMessage('');
     setSuccessMessage('');
+    setSharedLinkError('');
+    if (SHARE_LINK_PATH.test(window.location.pathname)) {
+      window.history.replaceState({}, '', '/');
+    }
   }
 
   async function handleCapture(imageBase64) {
@@ -123,11 +151,20 @@ export default function App() {
         {step !== STEP.CAMERA && step !== STEP.INGREDIENTS && (
           <>
             <FlashMessage type="success" message={successMessage} onDismiss={() => setSuccessMessage('')} />
-            <FlashMessage type="danger" message={errorMessage} onDismiss={() => setErrorMessage('')} />
+            <FlashMessage
+              type="danger"
+              message={errorMessage || sharedLinkError}
+              onDismiss={() => {
+                setErrorMessage('');
+                setSharedLinkError('');
+              }}
+            />
           </>
         )}
 
-        {step === STEP.HOME && <Home onStart={() => setStep(STEP.BASIC_INFO)} />}
+        {loadingSharedRecipe && <p className="profile-meta">Loading shared recipe…</p>}
+
+        {step === STEP.HOME && !loadingSharedRecipe && <Home onStart={() => setStep(STEP.BASIC_INFO)} />}
 
         {step === STEP.BASIC_INFO && (
           <BasicInfo
@@ -178,6 +215,18 @@ export default function App() {
 
         {step === STEP.RECIPE_DETAIL && selectedRecipe && (
           <RecipeDetail recipe={selectedRecipe} onGenerateNew={() => setStep(STEP.CAMERA)} onBackHome={goHome} />
+        )}
+
+        {step === STEP.SHARED_RECIPE && selectedRecipe && (
+          <>
+            <p className="hero-banner">
+              <span className="hero-emoji" aria-hidden="true">
+                🔗
+              </span>
+              Someone shared this recipe with you from Leftover to Recipe.
+            </p>
+            <RecipeDetail recipe={selectedRecipe} onGenerateNew={goHome} onBackHome={goHome} backLabel="Back to home" />
+          </>
         )}
 
         {step === STEP.MY_RECIPES && <MyRecipes onBack={goHome} onView={handleViewSavedRecipe} />}

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -58,3 +58,13 @@ export function saveToRecipeBook(recipe) {
 export function removeFromRecipeBook(id) {
   return request(`/api/recipe-book?id=${id}`, { method: 'DELETE' });
 }
+
+// ---- Public share links ----
+
+export function createShareLink(recipe) {
+  return postJSON('/api/share', recipe);
+}
+
+export function fetchSharedRecipe(id) {
+  return request(`/api/share?id=${id}`);
+}

--- a/web/src/components/ShareModal.jsx
+++ b/web/src/components/ShareModal.jsx
@@ -1,14 +1,21 @@
 import { useEffect, useRef, useState } from 'react';
 import Icon from './Icon.jsx';
+import { createShareLink } from '../api.js';
 
 // Set this once the app is live on the Play Store - shown as a CTA on the
-// generated share image and used by the "Get the app" button below.
-// Leave blank to hide both until the listing is ready.
+// generated share image. Leave blank to hide it until the listing is ready.
 const PLAY_STORE_URL = import.meta.env.VITE_PLAY_STORE_URL || '';
 const SITE_URL = import.meta.env.VITE_SITE_URL || 'https://leftover-to-recipe.vercel.app';
 
 const CARD_W = 1080;
 const CARD_H = 1350; // 4:5, plays nicely as an IG/FB feed post and a WhatsApp/Messenger attachment
+
+// A plain <a download> saves to the Downloads/Files location on most mobile
+// browsers, not the Photos/gallery app people expect - only the native share
+// sheet's "Save Image" action (or a manual long-press on the full image)
+// reliably lands in Photos. Route touch devices to "open in a new tab" so
+// they get that long-press option instead of a surprise Files download.
+const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0;
 
 function wrapText(ctx, text, maxWidth) {
   const words = text.split(' ');
@@ -27,7 +34,16 @@ function wrapText(ctx, text, maxWidth) {
   return lines;
 }
 
-async function renderCard(recipe) {
+function truncate(ctx, text, maxWidth) {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  let t = text;
+  while (t.length > 1 && ctx.measureText(`${t}…`).width > maxWidth) {
+    t = t.slice(0, -1);
+  }
+  return `${t}…`;
+}
+
+async function renderCard(recipe, shareUrl) {
   const canvas = document.createElement('canvas');
   canvas.width = CARD_W;
   canvas.height = CARD_H;
@@ -41,38 +57,39 @@ async function renderCard(recipe) {
   ctx.fillRect(0, 0, CARD_W, CARD_H);
 
   const pad = 72;
-  let y = 100;
+  const contentW = CARD_W - pad * 2;
+  let y = 96;
 
   // Brand row
-  ctx.font = '64px system-ui, sans-serif';
+  ctx.font = '56px system-ui, sans-serif';
   ctx.textBaseline = 'alphabetic';
   ctx.fillText('🍲', pad, y);
   ctx.fillStyle = '#217a46';
-  ctx.font = '600 40px Georgia, serif';
-  ctx.fillText('Leftover to Recipe', pad + 88, y - 8);
-  y += 70;
+  ctx.font = '600 36px Georgia, serif';
+  ctx.fillText('Leftover to Recipe', pad + 78, y - 6);
+  y += 62;
 
   // Badge
   ctx.fillStyle = recipe.isHealthy ? '#2f9e5c' : '#e05f2c';
   const badgeText = recipe.isHealthy ? '🥦 Healthy' : '🍩 Relax';
-  ctx.font = '600 30px system-ui, sans-serif';
-  const badgeW = ctx.measureText(badgeText).width + 48;
+  ctx.font = '600 28px system-ui, sans-serif';
+  const badgeW = ctx.measureText(badgeText).width + 44;
   ctx.beginPath();
-  ctx.roundRect(pad, y, badgeW, 56, 28);
+  ctx.roundRect(pad, y, badgeW, 52, 26);
   ctx.fill();
   ctx.fillStyle = '#ffffff';
-  ctx.fillText(badgeText, pad + 24, y + 38);
-  y += 110;
+  ctx.fillText(badgeText, pad + 22, y + 35);
+  y += 96;
 
   // Title
   ctx.fillStyle = '#1f2a24';
-  ctx.font = '700 60px Georgia, serif';
-  const titleLines = wrapText(ctx, recipe.title, CARD_W - pad * 2);
-  for (const line of titleLines.slice(0, 3)) {
+  ctx.font = '700 54px Georgia, serif';
+  const titleLines = wrapText(ctx, recipe.title, contentW);
+  for (const line of titleLines.slice(0, 2)) {
     ctx.fillText(line, pad, y);
-    y += 68;
+    y += 60;
   }
-  y += 24;
+  y += 20;
 
   // Divider
   ctx.strokeStyle = '#e8e4da';
@@ -81,59 +98,114 @@ async function renderCard(recipe) {
   ctx.moveTo(pad, y);
   ctx.lineTo(CARD_W - pad, y);
   ctx.stroke();
-  y += 56;
+  y += 46;
 
-  // Ingredients heading
+  // Two-column split: ingredients (left, narrower) + instructions (right, wider)
+  const colGap = 40;
+  const leftW = Math.round(contentW * 0.36);
+  const rightW = contentW - leftW - colGap;
+  const rightX = pad + leftW + colGap;
+  const sectionTop = y;
+
+  // Ingredients column
   ctx.fillStyle = '#217a46';
-  ctx.font = '700 34px system-ui, sans-serif';
+  ctx.font = '700 30px system-ui, sans-serif';
   ctx.fillText('Ingredients', pad, y);
-  y += 50;
-
+  let leftY = y + 44;
   ctx.fillStyle = '#1f2a24';
-  ctx.font = '32px system-ui, sans-serif';
-  const shown = recipe.ingredients.slice(0, 8);
-  for (const ingredient of shown) {
-    const lines = wrapText(ctx, `•  ${ingredient}`, CARD_W - pad * 2);
-    for (const line of lines) {
-      if (y > CARD_H - 220) break;
-      ctx.fillText(line, pad, y);
-      y += 46;
-    }
+  ctx.font = '27px system-ui, sans-serif';
+  const shownIngredients = recipe.ingredients.slice(0, 7);
+  for (const ingredient of shownIngredients) {
+    ctx.fillText(`•  ${truncate(ctx, ingredient, leftW - 20)}`, pad, leftY);
+    leftY += 40;
   }
-  if (recipe.ingredients.length > shown.length) {
+  if (recipe.ingredients.length > shownIngredients.length) {
     ctx.fillStyle = '#6b7568';
-    ctx.fillText(`+ ${recipe.ingredients.length - shown.length} more…`, pad, y);
-    y += 46;
+    ctx.fillText(`+${recipe.ingredients.length - shownIngredients.length} more`, pad, leftY);
+    leftY += 40;
+  }
+
+  // Instructions column
+  ctx.fillStyle = '#217a46';
+  ctx.font = '700 30px system-ui, sans-serif';
+  ctx.fillText('How to cook', rightX, sectionTop);
+  let rightY = sectionTop + 44;
+  ctx.font = '26px system-ui, sans-serif';
+  const cleanedSteps = recipe.instructions.map((s) => s.replace(/^\d+\.\s*/, ''));
+  const stepLimit = sectionTop + 520; // keep clear of the footer band
+  for (let i = 0; i < cleanedSteps.length && rightY < stepLimit; i++) {
+    ctx.fillStyle = '#217a46';
+    ctx.font = '700 26px system-ui, sans-serif';
+    ctx.fillText(`${i + 1}.`, rightX, rightY);
+    ctx.fillStyle = '#1f2a24';
+    ctx.font = '26px system-ui, sans-serif';
+    const lines = wrapText(ctx, cleanedSteps[i], rightW - 44).slice(0, 2);
+    for (const line of lines) {
+      ctx.fillText(line, rightX + 44, rightY);
+      rightY += 36;
+    }
+    rightY += 10;
+  }
+  if (cleanedSteps.length > 0 && rightY >= stepLimit) {
+    ctx.fillStyle = '#6b7568';
+    ctx.font = '24px system-ui, sans-serif';
+    ctx.fillText('Full steps in the app →', rightX, stepLimit + 10);
   }
 
   // Footer CTA
+  const footerH = shareUrl ? 168 : 132;
   ctx.fillStyle = '#217a46';
-  ctx.fillRect(0, CARD_H - 140, CARD_W, 140);
+  ctx.fillRect(0, CARD_H - footerH, CARD_W, footerH);
   ctx.fillStyle = '#ffffff';
-  ctx.font = '600 32px system-ui, sans-serif';
-  ctx.fillText('Turn your leftovers into a recipe 🍜', pad, CARD_H - 78);
-  ctx.font = '28px system-ui, sans-serif';
+  ctx.font = '600 30px system-ui, sans-serif';
+  ctx.fillText('Turn your leftovers into a recipe 🍜', pad, CARD_H - footerH + 48);
+  ctx.font = '26px system-ui, sans-serif';
   ctx.fillStyle = '#e5f5eb';
-  ctx.fillText(PLAY_STORE_URL ? 'Get the app on Google Play' : SITE_URL.replace(/^https?:\/\//, ''), pad, CARD_H - 36);
+  if (shareUrl) {
+    ctx.fillText(truncate(ctx, shareUrl.replace(/^https?:\/\//, ''), contentW), pad, CARD_H - footerH + 90);
+    if (PLAY_STORE_URL) {
+      ctx.fillText('Get the app on Google Play', pad, CARD_H - footerH + 130);
+    }
+  } else {
+    ctx.fillText(PLAY_STORE_URL ? 'Get the app on Google Play' : SITE_URL.replace(/^https?:\/\//, ''), pad, CARD_H - footerH + 90);
+  }
 
-  return new Promise((resolve) => canvas.toBlob((blob) => resolve({ blob, canvas }), 'image/png'));
+  return new Promise((resolve) => canvas.toBlob((blob) => resolve(blob), 'image/png'));
 }
 
 export default function ShareModal({ recipe, onClose }) {
   const [imageUrl, setImageUrl] = useState('');
   const [blob, setBlob] = useState(null);
-  const [copied, setCopied] = useState(false);
+  const [shareUrl, setShareUrl] = useState('');
+  const [linkState, setLinkState] = useState('creating'); // creating | ready | failed
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [copiedCaption, setCopiedCaption] = useState(false);
   const objectUrlRef = useRef('');
 
   useEffect(() => {
     let cancelled = false;
-    renderCard(recipe).then(({ blob: b }) => {
+
+    async function run() {
+      let url = '';
+      try {
+        const { id } = await createShareLink(recipe);
+        url = `${SITE_URL}/r/${id}`;
+      } catch (err) {
+        console.error('could not create share link:', err);
+      }
       if (cancelled) return;
-      const url = URL.createObjectURL(b);
-      objectUrlRef.current = url;
+      setShareUrl(url);
+      setLinkState(url ? 'ready' : 'failed');
+
+      const b = await renderCard(recipe, url);
+      if (cancelled) return;
+      const objectUrl = URL.createObjectURL(b);
+      objectUrlRef.current = objectUrl;
       setBlob(b);
-      setImageUrl(url);
-    });
+      setImageUrl(objectUrl);
+    }
+
+    run();
     return () => {
       cancelled = true;
       if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
@@ -141,7 +213,7 @@ export default function ShareModal({ recipe, onClose }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const shareText = `${recipe.title} — made from my leftovers with Leftover to Recipe! ${SITE_URL}`;
+  const shareText = `${recipe.title} — made from my leftovers with Leftover to Recipe!${shareUrl ? ` ${shareUrl}` : ''}`;
   const canNativeShare =
     typeof navigator !== 'undefined' &&
     navigator.canShare &&
@@ -154,6 +226,7 @@ export default function ShareModal({ recipe, onClose }) {
       await navigator.share({
         title: recipe.title,
         text: shareText,
+        url: shareUrl || undefined,
         files: [file]
       });
     } catch (err) {
@@ -164,41 +237,61 @@ export default function ShareModal({ recipe, onClose }) {
     }
   }
 
-  function handleDownload() {
+  function handleSaveImage() {
     if (!imageUrl) return;
+    if (isTouchDevice) {
+      // Opens the raw image so the OS long-press menu ("Save to Photos" /
+      // "Add to Photos") is available - a triggered <a download> here lands
+      // in Files/Downloads instead, which isn't what people expect.
+      window.open(imageUrl, '_blank');
+      return;
+    }
     const a = document.createElement('a');
     a.href = imageUrl;
     a.download = `${recipe.title.replace(/\s+/g, '-').toLowerCase()}.png`;
     a.click();
   }
 
-  async function handleCopyCaption() {
+  async function handleCopyLink() {
+    if (!shareUrl) return;
     try {
-      await navigator.clipboard.writeText(shareText);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      await navigator.clipboard.writeText(shareUrl);
+      setCopiedLink(true);
+      setTimeout(() => setCopiedLink(false), 2000);
     } catch {
-      // clipboard API unavailable - non-fatal, the caption is shown on screen too
+      // clipboard API unavailable - the link is shown on screen too
     }
   }
 
-  const webIntents = [
-    {
-      name: 'Facebook',
-      emoji: '📘',
-      url: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(SITE_URL)}&quote=${encodeURIComponent(shareText)}`
-    },
-    {
-      name: 'Messenger',
-      emoji: '💬',
-      url: `https://www.facebook.com/dialog/send?link=${encodeURIComponent(SITE_URL)}&app_id=&redirect_uri=${encodeURIComponent(SITE_URL)}`
-    },
-    {
-      name: 'WhatsApp',
-      emoji: '🟢',
-      url: `https://wa.me/?text=${encodeURIComponent(shareText)}`
+  async function handleCopyCaption() {
+    try {
+      await navigator.clipboard.writeText(shareText);
+      setCopiedCaption(true);
+      setTimeout(() => setCopiedCaption(false), 2000);
+    } catch {
+      // clipboard API unavailable - non-fatal
     }
-  ];
+  }
+
+  const webIntents = shareUrl
+    ? [
+        {
+          name: 'Facebook',
+          emoji: '📘',
+          url: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}&quote=${encodeURIComponent(shareText)}`
+        },
+        {
+          name: 'Messenger',
+          emoji: '💬',
+          url: `https://www.facebook.com/dialog/send?link=${encodeURIComponent(shareUrl)}&app_id=&redirect_uri=${encodeURIComponent(shareUrl)}`
+        },
+        {
+          name: 'WhatsApp',
+          emoji: '🟢',
+          url: `https://wa.me/?text=${encodeURIComponent(shareText)}`
+        }
+      ]
+    : [];
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
@@ -209,12 +302,26 @@ export default function ShareModal({ recipe, onClose }) {
 
         <h3>Share this recipe</h3>
         <p className="profile-meta" style={{ marginBottom: 'var(--space-4)' }}>
-          A shareable image is generated below with the recipe, ready for socials.
+          A shareable image is generated below, plus a link straight back to this recipe.
         </p>
 
         <div className="share-preview">
           {imageUrl ? <img src={imageUrl} alt={`${recipe.title} recipe card`} /> : <div className="share-preview-loading">Generating image…</div>}
         </div>
+
+        {linkState === 'ready' && (
+          <div className="share-link-row">
+            <input type="text" readOnly value={shareUrl} onFocus={(e) => e.target.select()} />
+            <button type="button" className="btn btn-sm btn-outline" onClick={handleCopyLink}>
+              {copiedLink ? 'Copied ✓' : 'Copy'}
+            </button>
+          </div>
+        )}
+        {linkState === 'failed' && (
+          <p className="profile-meta" style={{ color: 'var(--color-danger)' }}>
+            Couldn't create a shareable link right now — you can still share the image below.
+          </p>
+        )}
 
         {canNativeShare && (
           <button type="button" className="btn btn-primary btn-block" onClick={handleNativeShare}>
@@ -222,15 +329,15 @@ export default function ShareModal({ recipe, onClose }) {
           </button>
         )}
 
-        <button type="button" className="btn btn-secondary btn-block" onClick={handleDownload} disabled={!imageUrl}>
-          <Icon name="download" size={16} /> Download image
+        <button type="button" className="btn btn-secondary btn-block" onClick={handleSaveImage} disabled={!imageUrl}>
+          <Icon name="download" size={16} /> {isTouchDevice ? 'Open image to save to Photos' : 'Download image'}
         </button>
 
         {!canNativeShare && (
           <>
             <p className="profile-meta" style={{ marginTop: 'var(--space-4)', marginBottom: 'var(--space-2)' }}>
-              Your browser doesn't support the native share sheet — post directly instead, or download the image
-              above and attach it to Instagram or WhatsApp manually.
+              Your browser doesn't support the native share sheet — post directly instead, or save the image above
+              and attach it to Instagram manually.
             </p>
             <div className="share-intent-row">
               {webIntents.map((intent) => (
@@ -249,7 +356,7 @@ export default function ShareModal({ recipe, onClose }) {
         )}
 
         <button type="button" className="link-back" style={{ marginTop: 'var(--space-4)' }} onClick={handleCopyCaption}>
-          {copied ? 'Caption copied ✓' : 'Copy caption text'}
+          {copiedCaption ? 'Caption copied ✓' : 'Copy caption text'}
         </button>
 
         {PLAY_STORE_URL && (

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -1126,6 +1126,23 @@ input[type='email']:focus {
   margin-top: var(--space-2);
 }
 
+.share-link-row {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.share-link-row input {
+  flex: 1;
+  min-width: 0;
+  border: 1.5px solid var(--color-border) !important;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-sunken) !important;
+  padding: 8px 12px !important;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
 .share-intent-row {
   display: flex;
   flex-wrap: wrap;

--- a/web/src/steps/RecipeDetail.jsx
+++ b/web/src/steps/RecipeDetail.jsx
@@ -4,7 +4,7 @@ import ShareModal from '../components/ShareModal.jsx';
 import LoginModal from '../components/LoginModal.jsx';
 import { saveToRecipeBook } from '../api.js';
 
-export default function RecipeDetail({ recipe, onGenerateNew, onBackHome }) {
+export default function RecipeDetail({ recipe, onGenerateNew, onBackHome, backLabel = 'Generate a new recipe' }) {
   const [rating, setRating] = useState(0);
   const [showThankYou, setShowThankYou] = useState(false);
   const [showShare, setShowShare] = useState(false);
@@ -39,7 +39,7 @@ export default function RecipeDetail({ recipe, onGenerateNew, onBackHome }) {
   return (
     <>
       <button type="button" className="link-back" onClick={onGenerateNew}>
-        <Icon name="arrowLeft" size={16} /> Generate a new recipe
+        <Icon name="arrowLeft" size={16} /> {backLabel}
       </button>
 
       <div className="card card-padded" style={{ marginTop: 'var(--space-4)' }}>


### PR DESCRIPTION
Fix share image/save UX, add public share links

- Save image: touch devices now open the image in a new tab instead of
  triggering an <a download>, so the OS long-press menu (Save to
  Photos/Add to Photos) is available. A plain download on mobile lands
  in Files/Downloads, not the Photos app people expect. Desktop keeps
  the regular download behavior.
- Share card: redesigned as a two-column layout with both Ingredients
  and a "How to cook" steps section (previously only showed a partial
  ingredient list, no instructions).
- Public share links: Share now creates a public, login-free snapshot
  of the recipe (new shared_recipes table, separate from each user's
  private saved_recipes) and surfaces a copyable link like
  leftover-to-recipe.vercel.app/r/<id>. That link is used in the share
  card footer, the Facebook/Messenger/WhatsApp intents, and the caption
  text. Opening the link (api/share.js, GET) loads that recipe directly
  via a lightweight client-side route in App.jsx, no login required.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
